### PR TITLE
feat: enforce node engine as we use es6 features

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
     "express": "^4.16.1",
     "jwt-simple": "^0.5.1",
     "morgan": "^1.9.0"
+  },
+  "engines" : {
+    "node": "^8"
   }
 }


### PR DESCRIPTION
Node is based on V8, Google Chrome's javascript engine (https://developers.google.com/v8/).

Javascript is based on a standard called [ECMAScript](https://fr.wikipedia.org/wiki/ECMAScript) and it has changed a lot in the last few years, bringing new features and breaking changes, so has V8 and Node.

Think of it like C++ 98 vs C++ 11, you can't compile C++ code with lambda in it with and old `g++` version.

This PR blocks usage of this project with Node versions different than 8.X.X